### PR TITLE
Add macOS build

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,33 @@
+# Build and push artifacts
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-push:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: CMake generate
+      env:
+        ARTIFACT_NAME: mrst-${{ runner.os }}
+      run: |
+        cmake -B build \
+          -DCMAKE_INSTALL_PREFIX=$ARTIFACT_NAME \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTING=OFF \
+          -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+      shell: bash
+    - name: Build
+      run: cmake --build build --target install -j
+    
+    - uses: actions/upload-artifact@v3
+      if: github.ref == 'refs/heads/main' # && github.repository == 'em-eight/mrst'
+      with:
+        name: mrst-${{ runner.os }}
+        path: mrst-${{ runner.os }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
       run: cmake --build build --target install -j
     
     - uses: actions/upload-artifact@v3
-      if: github.ref == 'refs/heads/main' # && github.repository == 'em-eight/mrst'
+      if: github.ref == 'refs/heads/main' && github.repository == 'em-eight/mrst'
       with:
         name: mrst-${{ runner.os }}
         path: mrst-${{ runner.os }}


### PR DESCRIPTION
These commits add macOS compilation. The binary produced is a dual-arch binary that will run on Intel and ARM Macs. Header files are also produced like the other zips. I've tested on my end the binary does run.